### PR TITLE
Send date with performance filter

### DIFF
--- a/controllers/PerformanceController.php
+++ b/controllers/PerformanceController.php
@@ -64,13 +64,14 @@ class PerformanceController {
             echo json_encode(['success' => false, 'message' => 'Partie corps ID is required']);
             return;
         }
-    
+
         $partie_corps_id = $_POST['partie_corps_id'];
+        $date = $_POST['date'] ?? date('Y-m-d');
+
         $performance = new Performance();
-        if($partie_corps_id == 0){
-            $date = $_GET['date'] ?? date('Y-m-d');
+        if ($partie_corps_id == 0) {
             $filteredPerformances = $performance->getByDate($date);
-        }else{
+        } else {
             $filteredPerformances = $performance->getAllbyPartieCorps($partie_corps_id);
         }
     

--- a/views/performances.php
+++ b/views/performances.php
@@ -3,7 +3,7 @@
 <form method="POST" action="/performance/create">
     <div class="form-group">
         <label for="date">Date</label>
-        <input type="date" class="form-control" id="date" name="date" value="<?= date('Y-m-d') ?>" required>
+        <input type="date" class="form-control" id="date" name="date" value="<?= $date ?>" required>
     </div>
     <div class="form-group">
         <label for="exercice_id">Exercice</label>
@@ -100,11 +100,12 @@ $(document).ready(function() {
 
     $('#partie_corps_id').change(function() {
         var partieCorpsId = $(this).val();
+        var currentDate = $('#date').val() || new URLSearchParams(window.location.search).get('date');
         if (partieCorpsId) {
             $.ajax({
                 url: '/performance/filter',
                 type: 'POST',
-                data: { partie_corps_id: partieCorpsId },
+                data: { partie_corps_id: partieCorpsId, date: currentDate },
                 dataType: 'json',
                 success: function(data) {
                     if (data.success) {


### PR DESCRIPTION
## Summary
- keep chosen date in the `performances` form
- include current date in the AJAX call when filtering performances
- use the posted date in `PerformanceController::filter`

## Testing
- `npm install` *(installs JS dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_6841c9abce8c83278a7c5946d44e6609