### PR TITLE
Fix French error message

### DIFF
--- a/views/performances.php
+++ b/views/performances.php
@@ -122,7 +122,7 @@ $(document).ready(function() {
                         });
                         $('table tbody').html(tbody);
                     } else {
-                        $('table tbody').html('<tr><td colspan="6">Pas de données disponible</td></tr>');
+                        $('table tbody').html('<tr><td colspan="6">Pas de données disponibles</td></tr>');
                     }
                 },
                 error: function(jqXHR, textStatus, errorThrown) {


### PR DESCRIPTION
## Summary
- correct pluralization for empty performance list message in performances.php

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_6841c9ad06c4832781a574129ed64493