### PR TITLE
Add Bootstrap dark mode with system theme

### DIFF
--- a/public/js/color-modes.js
+++ b/public/js/color-modes.js
@@ -1,0 +1,41 @@
+/*!
+ * Color mode toggler for Bootstrap's docs (https://getbootstrap.com/)
+ * Copyright 2011-2025 The Bootstrap Authors
+ * Licensed under the Creative Commons Attribution 3.0 Unported License.
+ */
+(() => {
+  'use strict'
+  const getStoredTheme = () => localStorage.getItem('theme')
+  const setStoredTheme = theme => localStorage.setItem('theme', theme)
+  const getPreferredTheme = () => {
+    const storedTheme = getStoredTheme()
+    if (storedTheme) {
+      return storedTheme
+    }
+    return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+  }
+  const setTheme = theme => {
+    if (theme === 'auto') {
+      document.documentElement.setAttribute('data-bs-theme', (window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'))
+    } else {
+      document.documentElement.setAttribute('data-bs-theme', theme)
+    }
+  }
+  setTheme(getPreferredTheme())
+  window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', () => {
+    const storedTheme = getStoredTheme()
+    if (storedTheme !== 'light' && storedTheme !== 'dark') {
+      setTheme(getPreferredTheme())
+    }
+  })
+  window.addEventListener('DOMContentLoaded', () => {
+    document.querySelectorAll('[data-bs-theme-value]')
+      .forEach(toggle => {
+        toggle.addEventListener('click', () => {
+          const theme = toggle.getAttribute('data-bs-theme-value')
+          setStoredTheme(theme)
+          setTheme(theme)
+        })
+      })
+  })
+})()

--- a/views/header.php
+++ b/views/header.php
@@ -1,9 +1,10 @@
 <!DOCTYPE html>
-<html lang="fr">
+<html lang="fr" data-bs-theme="auto">
 <head>
     <meta charset="UTF-8">
     <title><?php echo $title ?? 'Musculation'; ?></title>
     <link rel="stylesheet" href="/css/bootstrap.min.css">
+    <script src="/js/color-modes.js"></script>
     <script src="/js/jquery-3.7.1.min.js"></script>
 </head>
 <body>
@@ -34,6 +35,16 @@
                         <a class="nav-link" href="/register">Inscription</a>
                     </li>
                 <?php endif; ?>
+                <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" id="themeDropdown" role="button" data-bs-toggle="dropdown" aria-expanded="false">
+                        Thème
+                    </a>
+                    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="themeDropdown">
+                        <li><a class="dropdown-item" href="#" data-bs-theme-value="light">Clair</a></li>
+                        <li><a class="dropdown-item" href="#" data-bs-theme-value="dark">Sombre</a></li>
+                        <li><a class="dropdown-item" href="#" data-bs-theme-value="auto">Système</a></li>
+                    </ul>
+                </li>
             </ul>
         </div>
     </nav>


### PR DESCRIPTION
## Summary
- add Bootstrap color mode script
- load script and theme dropdown in header
- default theme to system preference

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841d374965483279a560ba302e8149c