### PR TITLE
Add username validation with live check

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,9 @@ C'est une tentative d'application web pour suivre ma progression a la muscu en p
 ## Système d'authentification
 
 L'application dispose maintenant d'un système simple d'inscription et de connexion.
-Les utilisateurs peuvent s'enregistrer via `/register`, se connecter via `/login`
-et se déconnecter via `/logout`.
+Les utilisateurs créent un compte avec une adresse email, un nom d'utilisateur et un mot de passe.
+La connexion se fait uniquement avec le nom d'utilisateur via `/login`. L'inscription s'effectue via `/register`,
+et il est possible de se déconnecter via `/logout`.
 
 Les mots de passe sont chiffrés en base de données via `password_hash`.
 

--- a/config/routes.php
+++ b/config/routes.php
@@ -12,5 +12,6 @@ return [
     ['POST', '/login', 'UserController#login'],
     ['GET', '/register', 'UserController#register'],
     ['POST', '/register', 'UserController#register'],
+    ['GET', '/check-username', 'UserController#checkUsername'],
     ['GET', '/logout', 'UserController#logout'],
 ];

--- a/controllers/UserController.php
+++ b/controllers/UserController.php
@@ -5,13 +5,13 @@ class UserController {
     public function login() {
         if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $userModel = new User();
-            $user = $userModel->findByEmail($_POST['email']);
+            $user = $userModel->findByUsername($_POST['username']);
             if ($user && password_verify($_POST['password'], $user['password'])) {
                 $_SESSION['user_id'] = $user['id'];
                 header('Location: /');
                 exit;
             } else {
-                $error = 'Email ou mot de passe invalide';
+                $error = 'Nom d\'utilisateur ou mot de passe invalide';
             }
         }
         require_once __DIR__ . '/../views/login.php';
@@ -22,13 +22,24 @@ class UserController {
             $userModel = new User();
             if ($userModel->findByEmail($_POST['email'])) {
                 $error = 'Cet email est déjà utilisé';
+            } elseif (!preg_match('/^[a-zA-Z0-9]{3,18}$/', $_POST['username'])) {
+                $error = "Le nom d'utilisateur doit faire entre 3 et 18 caractères alphanumériques";
+            } elseif ($userModel->findByUsername($_POST['username'])) {
+                $error = "Ce nom d'utilisateur est déjà pris";
             } else {
-                $userModel->create($_POST['email'], $_POST['password']);
+                $userModel->create($_POST['email'], $_POST['username'], $_POST['password']);
                 header('Location: /login');
                 exit;
             }
         }
         require_once __DIR__ . '/../views/register.php';
+    }
+
+    public function checkUsername() {
+        $userModel = new User();
+        $exists = $userModel->findByUsername($_GET['username']);
+        header('Content-Type: application/json');
+        echo json_encode(['available' => $exists ? false : true]);
     }
 
     public function logout() {

--- a/models/User.php
+++ b/models/User.php
@@ -12,10 +12,16 @@ class User {
         return $stmt->fetch(PDO::FETCH_ASSOC);
     }
 
-    public function create($email, $password) {
+    public function findByUsername($username) {
+        $stmt = $this->pdo->prepare("SELECT * FROM users WHERE username = :username");
+        $stmt->execute(['username' => $username]);
+        return $stmt->fetch(PDO::FETCH_ASSOC);
+    }
+
+    public function create($email, $username, $password) {
         $hash = password_hash($password, PASSWORD_DEFAULT);
-        $stmt = $this->pdo->prepare("INSERT INTO users (email, password) VALUES (:email, :password)");
-        $stmt->execute(['email' => $email, 'password' => $hash]);
+        $stmt = $this->pdo->prepare("INSERT INTO users (email, username, password) VALUES (:email, :username, :password)");
+        $stmt->execute(['email' => $email, 'username' => $username, 'password' => $hash]);
     }
 }
 ?>

--- a/public/js/register.js
+++ b/public/js/register.js
@@ -1,0 +1,22 @@
+$(document).ready(function() {
+    $('#username').on('input', function() {
+        var username = $(this).val();
+        var feedback = $('#username-feedback');
+
+        if (username.length < 3 || username.length > 18 || !/^[a-zA-Z0-9]+$/.test(username)) {
+            feedback.text("Le nom d'utilisateur doit comporter entre 3 et 18 lettres ou chiffres.")
+                    .removeClass('text-success').addClass('text-danger');
+            return;
+        }
+
+        $.get('/check-username', { username: username }, function(data) {
+            if (data.available) {
+                feedback.text('Nom d\'utilisateur disponible')
+                        .removeClass('text-danger').addClass('text-success');
+            } else {
+                feedback.text('Nom d\'utilisateur d\u00e9j\u00e0 pris')
+                        .removeClass('text-success').addClass('text-danger');
+            }
+        }, 'json');
+    });
+});

--- a/views/login.php
+++ b/views/login.php
@@ -8,8 +8,8 @@ include 'header.php';
 <?php endif; ?>
 <form method="POST" action="/login">
     <div class="form-group">
-        <label for="email">Email</label>
-        <input type="email" class="form-control" id="email" name="email" required>
+        <label for="username">Nom d'utilisateur</label>
+        <input type="text" class="form-control" id="username" name="username" required>
     </div>
     <div class="form-group">
         <label for="password">Mot de passe</label>

--- a/views/register.php
+++ b/views/register.php
@@ -8,6 +8,11 @@ include 'header.php';
 <?php endif; ?>
 <form method="POST" action="/register">
     <div class="form-group">
+        <label for="username">Nom d'utilisateur</label>
+        <input type="text" class="form-control" id="username" name="username" required minlength="3" maxlength="18" pattern="[A-Za-z0-9]{3,18}">
+        <small id="username-feedback" class="form-text"></small>
+    </div>
+    <div class="form-group">
         <label for="email">Email</label>
         <input type="email" class="form-control" id="email" name="email" required>
     </div>
@@ -18,4 +23,5 @@ include 'header.php';
     <button type="submit" class="btn btn-primary my-2">S'inscrire</button>
 </form>
 <p>Déjà un compte ? <a href="/login">Connectez-vous</a></p>
+<script src="/js/register.js"></script>
 <?php include 'footer.php'; ?>


### PR DESCRIPTION
## Summary
- create username field in registration form and check availability with AJAX
- add endpoint and controller logic to validate usernames
- swap login to use username instead of email
- document new flow in README

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6841d99889f88327837ce5592734cd37