### PR TITLE
Ajout du filtrage complet et validation dynamique

### DIFF
--- a/controllers/PerformanceController.php
+++ b/controllers/PerformanceController.php
@@ -7,7 +7,7 @@ class PerformanceController {
     public function index() {
         $date = $_GET['date'] ?? date('Y-m-d');
         $performance = new Performance();
-        $performances = $performance->getByDate($date, $_SESSION['user_id']);
+        $performances = $performance->getAll($_SESSION['user_id']);
         $exercice = new Exercice();
         $exercices = $exercice->getAll($_SESSION['user_id']);
         $parties = $exercice->getAllPartiesCorps();
@@ -66,11 +66,10 @@ class PerformanceController {
         }
 
         $partie_corps_id = $_POST['partie_corps_id'];
-        $date = $_POST['date'] ?? date('Y-m-d');
 
         $performance = new Performance();
         if ($partie_corps_id == 0) {
-            $filteredPerformances = $performance->getByDate($date, $_SESSION['user_id']);
+            $filteredPerformances = $performance->getAll($_SESSION['user_id']);
         } else {
             $filteredPerformances = $performance->getAllbyPartieCorps($partie_corps_id, $_SESSION['user_id']);
         }

--- a/models/Performance.php
+++ b/models/Performance.php
@@ -13,6 +13,18 @@ class Performance {
         return $stmt->fetchAll(PDO::FETCH_ASSOC);
     }
 
+    public function getAll($user_id) {
+        $stmt = $this->pdo->prepare(
+            "SELECT p.id AS idPerf, p.date, p.poids, p.series, p.repetitions, e.nom AS nomExos
+             FROM performances p
+             JOIN exercices e ON p.exercice_id = e.id
+             WHERE p.user_id = :user_id
+             ORDER BY p.date DESC"
+        );
+        $stmt->execute(['user_id' => $user_id]);
+        return $stmt->fetchAll(PDO::FETCH_ASSOC);
+    }
+
     public function getLastByExerciceId($exercice_id, $user_id) {
         $stmt = $this->pdo->prepare("SELECT * FROM performances WHERE exercice_id = :exercice_id AND user_id = :user_id ORDER BY date DESC LIMIT 1");
         $stmt->execute(['exercice_id' => $exercice_id, 'user_id' => $user_id]);

--- a/views/performances.php
+++ b/views/performances.php
@@ -101,38 +101,35 @@ $(document).ready(function() {
     $('#partie_corps_id').change(function() {
         var partieCorpsId = $(this).val();
         var currentDate = $('#date').val() || new URLSearchParams(window.location.search).get('date');
-        if (partieCorpsId) {
-            $.ajax({
-                url: '/performance/filter',
-                type: 'POST',
-                data: { partie_corps_id: partieCorpsId, date: currentDate },
-                dataType: 'json',
-                success: function(data) {
-                    if (data.success) {
-                        var performances = data.performances;
-                        var tbody = '';
-                        performances.forEach(function(performance) {
-                            tbody += '<tr>';
-                            tbody += '<td>' + performance.idPerf + '</td>';
-                            tbody += '<td>' + performance.date + '</td>';
-                            tbody += '<td>' + performance.nomExos + '</td>';
-                            tbody += '<td>' + performance.poids + '</td>';
-                            tbody += '<td>' + performance.series + '</td>';
-                            tbody += '<td>' + performance.repetitions + '</td>';
-                            tbody += '</tr>';
-                        });
-                        $('table tbody').html(tbody);
-                    } else {
-                        $('table tbody').html('<tr><td colspan="6">Pas de données disponibles</td></tr>');
-                    }
-                },
-                error: function(jqXHR, textStatus, errorThrown) {
-                    console.error('Error:', textStatus, errorThrown);
+
+        $.ajax({
+            url: '/performance/filter',
+            type: 'POST',
+            data: { partie_corps_id: partieCorpsId, date: currentDate },
+            dataType: 'json',
+            success: function(data) {
+                if (data.success) {
+                    var performances = data.performances;
+                    var tbody = '';
+                    performances.forEach(function(performance) {
+                        tbody += '<tr>';
+                        tbody += '<td>' + performance.idPerf + '</td>';
+                        tbody += '<td>' + performance.date + '</td>';
+                        tbody += '<td>' + performance.nomExos + '</td>';
+                        tbody += '<td>' + performance.poids + '</td>';
+                        tbody += '<td>' + performance.series + '</td>';
+                        tbody += '<td>' + performance.repetitions + '</td>';
+                        tbody += '</tr>';
+                    });
+                    $('table tbody').html(tbody);
+                } else {
+                    $('table tbody').html('<tr><td colspan="6">Pas de données disponibles</td></tr>');
                 }
-            });
-        } else {
-            $('table tbody').html('');
-        }
+            },
+            error: function(jqXHR, textStatus, errorThrown) {
+                console.error('Error:', textStatus, errorThrown);
+            }
+        });
     });
 });
 </script>


### PR DESCRIPTION
## Summary
- afficher toutes les performances par défaut
- filtrer les performances même pour l'option "toutes"
- ajouter une méthode `getAll` dans `Performance`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841dc8c193c8327a459c5ef1e067c2a