### PR TITLE
Affichage graphique des performances sur l'accueil

### DIFF
--- a/controllers/HomeController.php
+++ b/controllers/HomeController.php
@@ -1,7 +1,12 @@
 <?php
 
+require_once __DIR__ . '/../models/Performance.php';
+
 class HomeController {
     public function index() {
+        $performanceModel = new Performance();
+        $performances = $performanceModel->getAll($_SESSION['user_id']);
+
         require_once __DIR__ . '/../views/home.php';
     }
 }

--- a/models/Performance.php
+++ b/models/Performance.php
@@ -15,7 +15,7 @@ class Performance {
 
     public function getAll($user_id) {
         $stmt = $this->pdo->prepare(
-            "SELECT p.id AS idPerf, p.date, p.poids, p.series, p.repetitions, e.nom AS nomExos
+            "SELECT p.id AS idPerf, p.date, p.poids, p.series, p.repetitions, e.nom AS nomExos, e.id AS exercice_id
              FROM performances p
              JOIN exercices e ON p.exercice_id = e.id
              WHERE p.user_id = :user_id

--- a/views/home.php
+++ b/views/home.php
@@ -1,8 +1,48 @@
 <?php include 'header.php'; ?>
 <h1>Accueil</h1>
 <p>Bienvenue sur votre application de suivi de musculation.</p>
-<div class="mt-4">
+
+<div class="my-4">
     <a href="/exercices" class="btn btn-primary">Voir les Exercices</a>
     <a href="/performances" class="btn btn-secondary">Voir les Performances</a>
 </div>
+
+<?php if (!empty($performances)): ?>
+    <div id="chartContainer" style="height: 400px; width: 100%;"></div>
+    <script src="/js/canvasjs.min.js"></script>
+    <script>
+        const rawData = <?php echo json_encode($performances); ?>;
+        const grouped = {};
+        rawData.forEach(p => {
+            if (!grouped[p.exercice_id]) {
+                grouped[p.exercice_id] = {
+                    name: p.nomExos,
+                    dataPoints: []
+                };
+            }
+            grouped[p.exercice_id].dataPoints.push({ x: new Date(p.date), y: parseFloat(p.poids) });
+        });
+
+        const chart = new CanvasJS.Chart("chartContainer", {
+            animationEnabled: true,
+            theme: "light2",
+            title: { text: "Performances enregistrées" },
+            axisX: { valueFormatString: "DD MMM YY" },
+            axisY: { title: "Poids (kg)", includeZero: true },
+            legend: { cursor: "pointer" }
+        });
+
+        chart.options.data = Object.values(grouped).map(g => ({
+            type: "spline",
+            name: g.name,
+            showInLegend: true,
+            dataPoints: g.dataPoints.reverse()
+        }));
+
+        chart.render();
+    </script>
+<?php else: ?>
+    <p class="mt-4">Aucune performance enregistrée pour le moment. <a href="/performances">Ajoutez vos premières performances</a>.</p>
+<?php endif; ?>
+
 <?php include 'footer.php'; ?>


### PR DESCRIPTION
## Summary
- afficher les performances de tous les exercices sur la page d'accueil
- récupérer les données dans `HomeController`
- exposer l'identifiant de l'exercice dans `Performance::getAll`

## Testing
- `php -l controllers/HomeController.php` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e0e640908327b3da797b3351fd94